### PR TITLE
Fix warning in Factory.php getParams

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -410,7 +410,8 @@ class Factory
 			}
 			return $instances[$jname];
 		} catch (Exception $e) {
-			return new Registry();
+			$registry = new Registry();
+			return $registry;
 		}
 	}
 


### PR DESCRIPTION
Can't directly return new class.  Assign to variable first, to avoid "only variables can be passed by reference" warning.